### PR TITLE
Fixed the DVB-T data for Braunschweig Broitzem and Kraftwerk

### DIFF
--- a/src/terrestrial.xml
+++ b/src/terrestrial.xml
@@ -620,17 +620,16 @@
 		<transponder centre_frequency="674000000" bandwidth="0" constellation="2" code_rate_hp="1" code_rate_lp="6" guard_interval="2" transmission_mode="1" hierarchy_information="0" inversion="2" />
 	</terrestrial>
 	<terrestrial name="Berlin/Brandenburg(de) (Europe DVB-T/T2)" flags="5"> 
-		<ts centre_frequency="506000000" bandwidth="0" code_rate_HP="5" code_rate_LP="5" modulation="3" transmission_mode="2" guard_interval="4" hierarchy="4" inversion="2" flags="0" system="0" plpid="0" scantime="27/4/2016"/>
-		<ts centre_frequency="522000000" bandwidth="0" code_rate_HP="5" code_rate_LP="5" modulation="3" transmission_mode="2" guard_interval="4" hierarchy="4" inversion="2" flags="0" system="0" plpid="0" scantime="27/4/2016"/>
-		<ts centre_frequency="570000000" bandwidth="0" code_rate_HP="5" code_rate_LP="5" modulation="3" transmission_mode="2" guard_interval="4" hierarchy="4" inversion="2" flags="0" system="0" plpid="0" scantime="27/4/2016"/>
-		<ts centre_frequency="618000000" bandwidth="0" code_rate_HP="5" code_rate_LP="5" modulation="3" transmission_mode="2" guard_interval="4" hierarchy="4" inversion="2" flags="0" system="0" plpid="0" scantime="27/4/2016"/>
-		<ts centre_frequency="642000000" bandwidth="0" code_rate_HP="5" code_rate_LP="5" modulation="3" transmission_mode="2" guard_interval="4" hierarchy="4" inversion="2" flags="0" system="1" plpid="0" scantime="27/4/2016"/><!-- Test für T2 -->
-		<ts centre_frequency="642000000" bandwidth="0" code_rate_HP="5" code_rate_LP="5" modulation="3" transmission_mode="6" guard_interval="1" hierarchy="4" inversion="2" flags="0" system="1" plpid="1" scantime="27/4/2016"/><!-- Test für T2 -->
-		<ts centre_frequency="658000000" bandwidth="0" code_rate_HP="5" code_rate_LP="5" modulation="3" transmission_mode="2" guard_interval="4" hierarchy="4" inversion="2" flags="0" system="0" plpid="0" scantime="27/4/2016"/>
-		<ts centre_frequency="682000000" bandwidth="0" code_rate_HP="1" code_rate_LP="0" modulation="1" transmission_mode="1" guard_interval="2" hierarchy="0" inversion="2" flags="0" system="0" plpid="0" scantime="27/4/2016"/>
-		<ts centre_frequency="706000000" bandwidth="0" code_rate_HP="5" code_rate_LP="5" modulation="3" transmission_mode="2" guard_interval="4" hierarchy="4" inversion="2" flags="0" system="0" plpid="0" scantime="27/4/2016"/>
-		<ts centre_frequency="754000000" bandwidth="0" code_rate_HP="5" code_rate_LP="5" modulation="3" transmission_mode="2" guard_interval="4" hierarchy="4" inversion="2" flags="0" system="0" plpid="0" scantime="27/4/2016"/>
-		<ts centre_frequency="778000000" bandwidth="0" code_rate_HP="5" code_rate_LP="5" modulation="3" transmission_mode="2" guard_interval="4" hierarchy="4" inversion="2" flags="0" system="0" plpid="0" scantime="27/4/2016"/>
+		<ts centre_frequency="506000000" bandwidth="0" priority="1" Time_Slicing_indicator="1" MPE_FEC_indicator="1" constellation="1" hierachy_information="0" code_rate_HP_stream="1" code_rate_LP_stream="0" guard_interval="2" transmission_mode="1" other_frequency_flag="0" networktype="2" satellite="DVB-T" scantime="21/8/2012 14:17:04"/>
+		<ts centre_frequency="522000000" bandwidth="0" priority="1" Time_Slicing_indicator="1" MPE_FEC_indicator="1" constellation="1" hierachy_information="0" code_rate_HP_stream="1" code_rate_LP_stream="0" guard_interval="2" transmission_mode="1" other_frequency_flag="0" networktype="2" satellite="DVB-T" scantime="21/8/2012 14:17:10"/>
+		<ts centre_frequency="570000000" bandwidth="0" priority="1" Time_Slicing_indicator="1" MPE_FEC_indicator="1" constellation="1" hierachy_information="0" code_rate_HP_stream="1" code_rate_LP_stream="0" guard_interval="3" transmission_mode="1" other_frequency_flag="1" networktype="2" satellite="DVB-T" scantime="21/8/2012 14:17:15"/>
+		<ts centre_frequency="618000000" bandwidth="0" priority="1" Time_Slicing_indicator="1" MPE_FEC_indicator="1" constellation="2" hierachy_information="0" code_rate_HP_stream="1" code_rate_LP_stream="0" guard_interval="2" transmission_mode="1" other_frequency_flag="0" networktype="2" satellite="DVB-T" scantime="21/8/2012 14:17:24"/>
+		<ts centre_frequency="642000000" bandwidth="0" constellation="3"/><!-- DVB-T2 Testbetrieb -->
+		<ts centre_frequency="658000000" bandwidth="0" priority="1" Time_Slicing_indicator="1" MPE_FEC_indicator="1" constellation="1" hierachy_information="0" code_rate_HP_stream="1" code_rate_LP_stream="0" guard_interval="2" transmission_mode="1" other_frequency_flag="0" networktype="2" satellite="DVB-T" scantime="21/8/2012 14:17:32"/>
+		<ts centre_frequency="682000000" bandwidth="0" priority="1" Time_Slicing_indicator="1" MPE_FEC_indicator="1" constellation="1" hierachy_information="0" code_rate_HP_stream="1" code_rate_LP_stream="0" guard_interval="2" transmission_mode="1" other_frequency_flag="0" networktype="2" satellite="DVB-T" scantime="21/8/2012 14:17:44"/>
+		<ts centre_frequency="706000000" bandwidth="0" priority="1" Time_Slicing_indicator="1" MPE_FEC_indicator="1" constellation="1" hierachy_information="0" code_rate_HP_stream="1" code_rate_LP_stream="0" guard_interval="2" transmission_mode="1" other_frequency_flag="0" networktype="2" satellite="DVB-T" scantime="21/8/2012 14:17:49"/>
+		<ts centre_frequency="754000000" bandwidth="0" priority="1" Time_Slicing_indicator="1" MPE_FEC_indicator="1" constellation="1" hierachy_information="0" code_rate_HP_stream="1" code_rate_LP_stream="0" guard_interval="2" transmission_mode="1" other_frequency_flag="0" networktype="2" satellite="DVB-T" scantime="21/8/2012 14:18:01"/>
+		<ts centre_frequency="778000000" bandwidth="0" priority="1" Time_Slicing_indicator="1" MPE_FEC_indicator="1" constellation="1" hierachy_information="0" code_rate_HP_stream="1" code_rate_LP_stream="0" guard_interval="2" transmission_mode="1" other_frequency_flag="0" networktype="2" satellite="DVB-T" scantime="21/8/2012 14:18:10"/>
 	</terrestrial>
 	<terrestrial name="Bremen/Bremerhaven(de) (Europe DVB-T/T2)" flags="5">
 		<transponder centre_frequency="482000000" bandwidth="0" constellation="1" code_rate_hp="1" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2" />
@@ -686,6 +685,15 @@
 		<transponder centre_frequency="530000000" bandwidth="0" constellation="1" code_rate_hp="1" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2" />
 		<transponder centre_frequency="594000000" bandwidth="0" constellation="1" code_rate_hp="1" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2" />
 		<transponder centre_frequency="658000000" bandwidth="0" constellation="1" code_rate_hp="1" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2" />
+		<transponder centre_frequency="786000000" bandwidth="0" constellation="1" code_rate_hp="1" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2" />
+	</terrestrial>
+	<terrestrial name="Braunschweig(de) Broitzem+Kraftwerk(Europe DVB-T/T2)" flags="5">
+		<transponder centre_frequency="490000000" bandwidth="0" constellation="1" code_rate_hp="1" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2" />
+		<transponder centre_frequency="498000000" bandwidth="0" constellation="1" code_rate_hp="1" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2" />
+		<transponder centre_frequency="594000000" bandwidth="0" constellation="1" code_rate_hp="1" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2" />
+		<transponder centre_frequency="658000000" bandwidth="0" constellation="1" code_rate_hp="1" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2" />
+		<transponder centre_frequency="682000000" bandwidth="0" constellation="1" code_rate_hp="1" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2" />
+		<transponder centre_frequency="754000000" bandwidth="0" constellation="1" code_rate_hp="1" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2" />
 		<transponder centre_frequency="786000000" bandwidth="0" constellation="1" code_rate_hp="1" code_rate_lp="6" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="2" />
 	</terrestrial>
 	<terrestrial name="Hunau(de) (Europe DVB-T/T2)" flags="5">


### PR DESCRIPTION
- splitted Braunschweig and Hannover section
- added the current DVB-T data for Braunschweig Broitzem and Kraftwerk.

Source: http://www.dvb-t-portal.de/Regionen/index.php?region=46


