### PR TITLE
Add available transponders for Leipzig, Germany

### DIFF
--- a/src/terrestrial.xml
+++ b/src/terrestrial.xml
@@ -609,6 +609,15 @@
 		<transponder centre_frequency="826000000" bandwidth="0" />
 		<transponder centre_frequency="834000000" bandwidth="0" />
 	</terrestrial>
+        <terrestrial name="Leipzig (Europe DVB-T2)" flags="5" countrycode="DEU">
+                <transponder centre_frequency="498000000" bandwidth="0" />
+                <transponder centre_frequency="514000000" bandwidth="0" />
+                <transponder centre_frequency="530000000" bandwidth="0" />
+                <transponder centre_frequency="554000000" bandwidth="0" />
+                <transponder centre_frequency="586000000" bandwidth="0" />
+                <transponder centre_frequency="650000000" bandwidth="0" />
+                <transponder centre_frequency="698000000" bandwidth="0" />
+        </terrestrial>
 	<terrestrial name="Muenchen/Suedbayern (Europe DVB-T/T2)" flags="5" countrycode="DEU">
 		<transponder centre_frequency="514000000" bandwidth="0" />
 		<transponder centre_frequency="578000000" bandwidth="0" />


### PR DESCRIPTION
Successfully have tested this terrestrial.xml on an Octagon SF138 running openatv 6.1.