### PR TITLE
Add Greece DVB-T/T2 frequencies

### DIFF
--- a/src/terrestrial.xml
+++ b/src/terrestrial.xml
@@ -1679,6 +1679,48 @@
 		<transponder centre_frequency="770000000" bandwidth="0" system="0" constellation="3" guard_interval="4" transmission_mode="2" hierarchy_information="4" inversion="2"/><!-- Ch 58 -->
 		<transponder centre_frequency="778000000" bandwidth="0" system="0" constellation="3" guard_interval="4" transmission_mode="2" hierarchy_information="4" inversion="2"/><!-- Ch 59 -->
 	</terrestrial>
+	<terrestrial name="Greece (Europe DVB-T/T2)" flags="5" countrycode="GRC">
+		<transponder centre_frequency="474000000" bandwidth="0" constellation="3"/><!-- Ch 21 -->
+		<transponder centre_frequency="482000000" bandwidth="0" constellation="3"/><!-- Ch 22 -->
+		<transponder centre_frequency="490000000" bandwidth="0" constellation="3"/><!-- Ch 23 -->
+		<transponder centre_frequency="498000000" bandwidth="0" constellation="3"/><!-- Ch 24 -->
+		<transponder centre_frequency="506000000" bandwidth="0" constellation="3"/><!-- Ch 25 -->
+		<transponder centre_frequency="514000000" bandwidth="0" constellation="3"/><!-- Ch 26 -->
+		<transponder centre_frequency="522000000" bandwidth="0" constellation="3"/><!-- Ch 27 -->
+		<transponder centre_frequency="530000000" bandwidth="0" constellation="3"/><!-- Ch 28 -->
+		<transponder centre_frequency="538000000" bandwidth="0" constellation="3"/><!-- Ch 29 -->
+		<transponder centre_frequency="546000000" bandwidth="0" constellation="3"/><!-- Ch 30 -->
+		<transponder centre_frequency="554000000" bandwidth="0" constellation="3"/><!-- Ch 31 -->
+		<transponder centre_frequency="562000000" bandwidth="0" constellation="3"/><!-- Ch 32 -->
+		<transponder centre_frequency="570000000" bandwidth="0" constellation="3"/><!-- Ch 33 -->
+		<transponder centre_frequency="578000000" bandwidth="0" constellation="3"/><!-- Ch 34 -->
+		<transponder centre_frequency="586000000" bandwidth="0" constellation="3"/><!-- Ch 35 -->
+		<transponder centre_frequency="594000000" bandwidth="0" constellation="3"/><!-- Ch 36 -->
+		<transponder centre_frequency="602000000" bandwidth="0" constellation="3"/><!-- Ch 37 -->
+		<transponder centre_frequency="610000000" bandwidth="0" constellation="3"/><!-- Ch 38 -->
+		<transponder centre_frequency="618000000" bandwidth="0" constellation="3"/><!-- Ch 39 -->
+		<transponder centre_frequency="626000000" bandwidth="0" constellation="3"/><!-- Ch 40 -->
+		<transponder centre_frequency="634000000" bandwidth="0" constellation="3"/><!-- Ch 41 -->
+		<transponder centre_frequency="642000000" bandwidth="0" constellation="3"/><!-- Ch 42 -->
+		<transponder centre_frequency="650000000" bandwidth="0" constellation="3"/><!-- Ch 43 -->
+		<transponder centre_frequency="658000000" bandwidth="0" constellation="3"/><!-- Ch 44 -->
+		<transponder centre_frequency="666000000" bandwidth="0" constellation="3"/><!-- Ch 45 -->
+		<transponder centre_frequency="674000000" bandwidth="0" constellation="3"/><!-- Ch 46 -->
+		<transponder centre_frequency="682000000" bandwidth="0" constellation="3"/><!-- Ch 47 -->
+		<transponder centre_frequency="690000000" bandwidth="0" constellation="3"/><!-- Ch 48 -->
+		<transponder centre_frequency="698000000" bandwidth="0" constellation="3"/><!-- Ch 49 -->
+		<transponder centre_frequency="706000000" bandwidth="0" constellation="3"/><!-- Ch 50 -->
+		<transponder centre_frequency="714000000" bandwidth="0" constellation="3"/><!-- Ch 51 -->
+		<transponder centre_frequency="722000000" bandwidth="0" constellation="3"/><!-- Ch 52 -->
+		<transponder centre_frequency="730000000" bandwidth="0" constellation="3"/><!-- Ch 53 -->
+		<transponder centre_frequency="738000000" bandwidth="0" constellation="3"/><!-- Ch 54 -->
+		<transponder centre_frequency="746000000" bandwidth="0" constellation="3"/><!-- Ch 55 -->
+		<transponder centre_frequency="754000000" bandwidth="0" constellation="3"/><!-- Ch 56 -->
+		<transponder centre_frequency="762000000" bandwidth="0" constellation="3"/><!-- Ch 57 -->
+		<transponder centre_frequency="770000000" bandwidth="0" constellation="3"/><!-- Ch 58 -->
+		<transponder centre_frequency="778000000" bandwidth="0" constellation="3"/><!-- Ch 59 -->
+		<transponder centre_frequency="786000000" bandwidth="0" constellation="3"/><!-- Ch 60 -->
+	</terrestrial>
 	<terrestrial name="Békéscsaba  (Europe DVB-T/T2)" flags="5" countrycode="HUN">
 		<transponder centre_frequency="490000000" bandwidth="0" constellation="2" /><!-- Ch 23 A Mpx -->
 		<transponder centre_frequency="738000000" bandwidth="0" constellation="2" /><!-- Ch 54 B Mpx -->


### PR DESCRIPTION
Add Greece as an option for the DVB-T/T2 tuner configuration. Available UHF channels are 21-60.