### PR TITLE
Update frequency list for all regions of Spain

### DIFF
--- a/src/terrestrial.xml
+++ b/src/terrestrial.xml
@@ -874,18 +874,25 @@
 		<transponder centre_frequency="762000000" bandwidth="0" constellation="3"/><!-- Ch 57 -->
 		<transponder centre_frequency="770000000" bandwidth="0" constellation="3"/><!-- Ch 58 -->
 		<transponder centre_frequency="778000000" bandwidth="0" constellation="3"/><!-- Ch 59 -->
+		<transponder centre_frequency="786000000" bandwidth="0" constellation="3"/><!-- Ch 60 -->
 	</terrestrial>
 	<terrestrial name="Aragon (Europe DVB-T/T2)" flags="5" countrycode="ESP">
+		<transponder centre_frequency="474000000" bandwidth="0" constellation="3"/><!-- Ch 21 -->
 		<transponder centre_frequency="482000000" bandwidth="0" constellation="3"/><!-- Ch 22 -->
+		<transponder centre_frequency="490000000" bandwidth="0" constellation="3"/><!-- Ch 23 -->
+		<transponder centre_frequency="498000000" bandwidth="0" constellation="3"/><!-- Ch 24 -->
 		<transponder centre_frequency="506000000" bandwidth="0" constellation="3"/><!-- Ch 25 -->
 		<transponder centre_frequency="514000000" bandwidth="0" constellation="3"/><!-- Ch 26 -->
+		<transponder centre_frequency="522000000" bandwidth="0" constellation="3"/><!-- Ch 27 -->
 		<transponder centre_frequency="530000000" bandwidth="0" constellation="3"/><!-- Ch 28 -->
+		<transponder centre_frequency="538000000" bandwidth="0" constellation="3"/><!-- Ch 29 -->
 		<transponder centre_frequency="546000000" bandwidth="0" constellation="3"/><!-- Ch 30 -->
 		<transponder centre_frequency="554000000" bandwidth="0" constellation="3"/><!-- Ch 31 -->
 		<transponder centre_frequency="562000000" bandwidth="0" constellation="3"/><!-- Ch 32 -->
 		<transponder centre_frequency="570000000" bandwidth="0" constellation="3"/><!-- Ch 33 -->
 		<transponder centre_frequency="578000000" bandwidth="0" constellation="3"/><!-- Ch 34 -->
 		<transponder centre_frequency="586000000" bandwidth="0" constellation="3"/><!-- Ch 35 -->
+		<transponder centre_frequency="594000000" bandwidth="0" constellation="3"/><!-- Ch 36 -->
 		<transponder centre_frequency="602000000" bandwidth="0" constellation="3"/><!-- Ch 37 -->
 		<transponder centre_frequency="610000000" bandwidth="0" constellation="3"/><!-- Ch 38 -->
 		<transponder centre_frequency="618000000" bandwidth="0" constellation="3"/><!-- Ch 39 -->
@@ -896,31 +903,62 @@
 		<transponder centre_frequency="658000000" bandwidth="0" constellation="3"/><!-- Ch 44 -->
 		<transponder centre_frequency="666000000" bandwidth="0" constellation="3"/><!-- Ch 45 -->
 		<transponder centre_frequency="674000000" bandwidth="0" constellation="3"/><!-- Ch 46 -->
+		<transponder centre_frequency="682000000" bandwidth="0" constellation="3"/><!-- Ch 47 -->
 		<transponder centre_frequency="690000000" bandwidth="0" constellation="3"/><!-- Ch 48 -->
 		<transponder centre_frequency="698000000" bandwidth="0" constellation="3"/><!-- Ch 49 -->
 		<transponder centre_frequency="706000000" bandwidth="0" constellation="3"/><!-- Ch 50 -->
+		<transponder centre_frequency="714000000" bandwidth="0" constellation="3"/><!-- Ch 51 -->
 		<transponder centre_frequency="722000000" bandwidth="0" constellation="3"/><!-- Ch 52 -->
+		<transponder centre_frequency="730000000" bandwidth="0" constellation="3"/><!-- Ch 53 -->
 		<transponder centre_frequency="738000000" bandwidth="0" constellation="3"/><!-- Ch 54 -->
+		<transponder centre_frequency="746000000" bandwidth="0" constellation="3"/><!-- Ch 55 -->
 		<transponder centre_frequency="754000000" bandwidth="0" constellation="3"/><!-- Ch 56 -->
 		<transponder centre_frequency="762000000" bandwidth="0" constellation="3"/><!-- Ch 57 -->
+		<transponder centre_frequency="770000000" bandwidth="0" constellation="3"/><!-- Ch 58 -->
 		<transponder centre_frequency="778000000" bandwidth="0" constellation="3"/><!-- Ch 59 -->
+		<transponder centre_frequency="786000000" bandwidth="0" constellation="3"/><!-- Ch 60 -->
 	</terrestrial>
 	<terrestrial name="Asturias (Europe DVB-T/T2)" flags="5" countrycode="ESP">
+		<transponder centre_frequency="474000000" bandwidth="0" constellation="3"/><!-- Ch 21 -->
 		<transponder centre_frequency="482000000" bandwidth="0" constellation="3"/><!-- Ch 22 -->
+		<transponder centre_frequency="490000000" bandwidth="0" constellation="3"/><!-- Ch 23 -->
+		<transponder centre_frequency="498000000" bandwidth="0" constellation="3"/><!-- Ch 24 -->
 		<transponder centre_frequency="506000000" bandwidth="0" constellation="3"/><!-- Ch 25 -->
+		<transponder centre_frequency="514000000" bandwidth="0" constellation="3"/><!-- Ch 26 -->
 		<transponder centre_frequency="522000000" bandwidth="0" constellation="3"/><!-- Ch 27 -->
 		<transponder centre_frequency="530000000" bandwidth="0" constellation="3"/><!-- Ch 28 -->
+		<transponder centre_frequency="538000000" bandwidth="0" constellation="3"/><!-- Ch 29 -->
+		<transponder centre_frequency="546000000" bandwidth="0" constellation="3"/><!-- Ch 30 -->
+		<transponder centre_frequency="554000000" bandwidth="0" constellation="3"/><!-- Ch 31 -->
 		<transponder centre_frequency="562000000" bandwidth="0" constellation="3"/><!-- Ch 32 -->
+		<transponder centre_frequency="570000000" bandwidth="0" constellation="3"/><!-- Ch 33 -->
+		<transponder centre_frequency="578000000" bandwidth="0" constellation="3"/><!-- Ch 34 -->
 		<transponder centre_frequency="586000000" bandwidth="0" constellation="3"/><!-- Ch 35 -->
+		<transponder centre_frequency="594000000" bandwidth="0" constellation="3"/><!-- Ch 36 -->
+		<transponder centre_frequency="602000000" bandwidth="0" constellation="3"/><!-- Ch 37 -->
 		<transponder centre_frequency="610000000" bandwidth="0" constellation="3"/><!-- Ch 38 -->
 		<transponder centre_frequency="618000000" bandwidth="0" constellation="3"/><!-- Ch 39 -->
+		<transponder centre_frequency="626000000" bandwidth="0" constellation="3"/><!-- Ch 40 -->
+		<transponder centre_frequency="634000000" bandwidth="0" constellation="3"/><!-- Ch 41 -->
 		<transponder centre_frequency="642000000" bandwidth="0" constellation="3"/><!-- Ch 42 -->
 		<transponder centre_frequency="650000000" bandwidth="0" constellation="3"/><!-- Ch 43 -->
 		<transponder centre_frequency="658000000" bandwidth="0" constellation="3"/><!-- Ch 44 -->
 		<transponder centre_frequency="666000000" bandwidth="0" constellation="3"/><!-- Ch 45 -->
 		<transponder centre_frequency="674000000" bandwidth="0" constellation="3"/><!-- Ch 46 -->
 		<transponder centre_frequency="682000000" bandwidth="0" constellation="3"/><!-- Ch 47 -->
+		<transponder centre_frequency="690000000" bandwidth="0" constellation="3"/><!-- Ch 48 -->
+		<transponder centre_frequency="698000000" bandwidth="0" constellation="3"/><!-- Ch 49 -->
+		<transponder centre_frequency="706000000" bandwidth="0" constellation="3"/><!-- Ch 50 -->
+		<transponder centre_frequency="714000000" bandwidth="0" constellation="3"/><!-- Ch 51 -->
+		<transponder centre_frequency="722000000" bandwidth="0" constellation="3"/><!-- Ch 52 -->
+		<transponder centre_frequency="730000000" bandwidth="0" constellation="3"/><!-- Ch 53 -->
+		<transponder centre_frequency="738000000" bandwidth="0" constellation="3"/><!-- Ch 54 -->
+		<transponder centre_frequency="746000000" bandwidth="0" constellation="3"/><!-- Ch 55 -->
 		<transponder centre_frequency="754000000" bandwidth="0" constellation="3"/><!-- Ch 56 -->
+		<transponder centre_frequency="762000000" bandwidth="0" constellation="3"/><!-- Ch 57 -->
+		<transponder centre_frequency="770000000" bandwidth="0" constellation="3"/><!-- Ch 58 -->
+		<transponder centre_frequency="778000000" bandwidth="0" constellation="3"/><!-- Ch 59 -->
+		<transponder centre_frequency="786000000" bandwidth="0" constellation="3"/><!-- Ch 60 -->
 	</terrestrial>
 	<terrestrial name="Canarias (Europe DVB-T/T2)" flags="5" countrycode="ESP">
 		<transponder centre_frequency="474000000" bandwidth="0" constellation="3"/><!-- Ch 21 -->
@@ -948,56 +986,25 @@
 		<transponder centre_frequency="650000000" bandwidth="0" constellation="3"/><!-- Ch 43 -->
 		<transponder centre_frequency="658000000" bandwidth="0" constellation="3"/><!-- Ch 44 -->
 		<transponder centre_frequency="666000000" bandwidth="0" constellation="3"/><!-- Ch 45 -->
+		<transponder centre_frequency="674000000" bandwidth="0" constellation="3"/><!-- Ch 46 -->
 		<transponder centre_frequency="682000000" bandwidth="0" constellation="3"/><!-- Ch 47 -->
 		<transponder centre_frequency="690000000" bandwidth="0" constellation="3"/><!-- Ch 48 -->
 		<transponder centre_frequency="698000000" bandwidth="0" constellation="3"/><!-- Ch 49 -->
 		<transponder centre_frequency="706000000" bandwidth="0" constellation="3"/><!-- Ch 50 -->
+		<transponder centre_frequency="714000000" bandwidth="0" constellation="3"/><!-- Ch 51 -->
 		<transponder centre_frequency="722000000" bandwidth="0" constellation="3"/><!-- Ch 52 -->
+		<transponder centre_frequency="730000000" bandwidth="0" constellation="3"/><!-- Ch 53 -->
+		<transponder centre_frequency="738000000" bandwidth="0" constellation="3"/><!-- Ch 54 -->
 		<transponder centre_frequency="746000000" bandwidth="0" constellation="3"/><!-- Ch 55 -->
 		<transponder centre_frequency="754000000" bandwidth="0" constellation="3"/><!-- Ch 56 -->
+		<transponder centre_frequency="762000000" bandwidth="0" constellation="3"/><!-- Ch 57 -->
 		<transponder centre_frequency="770000000" bandwidth="0" constellation="3"/><!-- Ch 58 -->
 		<transponder centre_frequency="778000000" bandwidth="0" constellation="3"/><!-- Ch 59 -->
+		<transponder centre_frequency="786000000" bandwidth="0" constellation="3"/><!-- Ch 60 -->
 	</terrestrial>
 	<terrestrial name="Cantabria (Europe DVB-T/T2)" flags="5" countrycode="ESP">
-		<transponder centre_frequency="474000000" bandwidth="0" constellation="3" /><!-- Ch 21 -->
-		<transponder centre_frequency="482000000" bandwidth="0" constellation="3" /><!-- Ch 22 -->
-		<transponder centre_frequency="490000000" bandwidth="0" constellation="3" /><!-- Ch 23 -->
-		<transponder centre_frequency="498000000" bandwidth="0" constellation="3" /><!-- Ch 24 -->
-		<transponder centre_frequency="506000000" bandwidth="0" constellation="3" /><!-- Ch 25 -->
-		<transponder centre_frequency="514000000" bandwidth="0" constellation="3" /><!-- Ch 26 -->
-		<transponder centre_frequency="522000000" bandwidth="0" constellation="3" /><!-- Ch 27 -->
-		<transponder centre_frequency="530000000" bandwidth="0" constellation="3" /><!-- Ch 28 -->
-		<transponder centre_frequency="538000000" bandwidth="0" constellation="3" /><!-- Ch 29 -->
-		<transponder centre_frequency="546000000" bandwidth="0" constellation="3" /><!-- Ch 30 -->
-		<transponder centre_frequency="554000000" bandwidth="0" constellation="3" /><!-- Ch 31 -->
-		<transponder centre_frequency="562000000" bandwidth="0" constellation="3" /><!-- Ch 32 -->
-		<transponder centre_frequency="570000000" bandwidth="0" constellation="3" /><!-- Ch 33 -->
-		<transponder centre_frequency="578000000" bandwidth="0" constellation="3" /><!-- Ch 34 -->
-		<transponder centre_frequency="586000000" bandwidth="0" constellation="3" /><!-- Ch 35 -->
-		<transponder centre_frequency="594000000" bandwidth="0" constellation="3" /><!-- Ch 36 -->
-		<transponder centre_frequency="602000000" bandwidth="0" constellation="3" /><!-- Ch 37 -->
-		<transponder centre_frequency="610000000" bandwidth="0" constellation="3" /><!-- Ch 38 -->
-		<transponder centre_frequency="618000000" bandwidth="0" constellation="3" /><!-- Ch 39 -->
-		<transponder centre_frequency="626000000" bandwidth="0" constellation="3" /><!-- Ch 40 -->
-		<transponder centre_frequency="634000000" bandwidth="0" constellation="3" /><!-- Ch 41 -->
-		<transponder centre_frequency="642000000" bandwidth="0" constellation="3" /><!-- Ch 42 -->
-		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" /><!-- Ch 43 -->
-		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" /><!-- Ch 44 -->
-		<transponder centre_frequency="666000000" bandwidth="0" constellation="3" /><!-- Ch 45 -->
-		<transponder centre_frequency="674000000" bandwidth="0" constellation="3" /><!-- Ch 46 -->
-		<transponder centre_frequency="682000000" bandwidth="0" constellation="3" /><!-- Ch 47 -->
-		<transponder centre_frequency="690000000" bandwidth="0" constellation="3" /><!-- Ch 48 -->
-		<transponder centre_frequency="698000000" bandwidth="0" constellation="3" /><!-- Ch 49 -->
-		<transponder centre_frequency="706000000" bandwidth="0" constellation="3" /><!-- Ch 50 -->
-		<transponder centre_frequency="722000000" bandwidth="0" constellation="3" /><!-- Ch 52 -->
-		<transponder centre_frequency="746000000" bandwidth="0" constellation="3" /><!-- Ch 55 -->
-		<transponder centre_frequency="754000000" bandwidth="0" constellation="3" /><!-- Ch 56 -->
-		<transponder centre_frequency="762000000" bandwidth="0" constellation="3" /><!-- Ch 57 -->
-		<transponder centre_frequency="770000000" bandwidth="0" constellation="3" /><!-- Ch 58 -->
-		<transponder centre_frequency="778000000" bandwidth="0" constellation="3" /><!-- Ch 59 -->
-	</terrestrial>
-	<terrestrial name="Castilla-la Mancha (Europe DVB-T/T2)" flags="5" countrycode="ESP">
 		<transponder centre_frequency="474000000" bandwidth="0" constellation="3"/><!-- Ch 21 -->
+		<transponder centre_frequency="482000000" bandwidth="0" constellation="3"/><!-- Ch 22 -->
 		<transponder centre_frequency="490000000" bandwidth="0" constellation="3"/><!-- Ch 23 -->
 		<transponder centre_frequency="498000000" bandwidth="0" constellation="3"/><!-- Ch 24 -->
 		<transponder centre_frequency="506000000" bandwidth="0" constellation="3"/><!-- Ch 25 -->
@@ -1008,11 +1015,13 @@
 		<transponder centre_frequency="546000000" bandwidth="0" constellation="3"/><!-- Ch 30 -->
 		<transponder centre_frequency="554000000" bandwidth="0" constellation="3"/><!-- Ch 31 -->
 		<transponder centre_frequency="562000000" bandwidth="0" constellation="3"/><!-- Ch 32 -->
+		<transponder centre_frequency="570000000" bandwidth="0" constellation="3"/><!-- Ch 33 -->
 		<transponder centre_frequency="578000000" bandwidth="0" constellation="3"/><!-- Ch 34 -->
 		<transponder centre_frequency="586000000" bandwidth="0" constellation="3"/><!-- Ch 35 -->
 		<transponder centre_frequency="594000000" bandwidth="0" constellation="3"/><!-- Ch 36 -->
 		<transponder centre_frequency="602000000" bandwidth="0" constellation="3"/><!-- Ch 37 -->
 		<transponder centre_frequency="610000000" bandwidth="0" constellation="3"/><!-- Ch 38 -->
+		<transponder centre_frequency="618000000" bandwidth="0" constellation="3"/><!-- Ch 39 -->
 		<transponder centre_frequency="626000000" bandwidth="0" constellation="3"/><!-- Ch 40 -->
 		<transponder centre_frequency="634000000" bandwidth="0" constellation="3"/><!-- Ch 41 -->
 		<transponder centre_frequency="642000000" bandwidth="0" constellation="3"/><!-- Ch 42 -->
@@ -1024,13 +1033,58 @@
 		<transponder centre_frequency="690000000" bandwidth="0" constellation="3"/><!-- Ch 48 -->
 		<transponder centre_frequency="698000000" bandwidth="0" constellation="3"/><!-- Ch 49 -->
 		<transponder centre_frequency="706000000" bandwidth="0" constellation="3"/><!-- Ch 50 -->
+		<transponder centre_frequency="714000000" bandwidth="0" constellation="3"/><!-- Ch 51 -->
 		<transponder centre_frequency="722000000" bandwidth="0" constellation="3"/><!-- Ch 52 -->
 		<transponder centre_frequency="730000000" bandwidth="0" constellation="3"/><!-- Ch 53 -->
 		<transponder centre_frequency="738000000" bandwidth="0" constellation="3"/><!-- Ch 54 -->
 		<transponder centre_frequency="746000000" bandwidth="0" constellation="3"/><!-- Ch 55 -->
 		<transponder centre_frequency="754000000" bandwidth="0" constellation="3"/><!-- Ch 56 -->
 		<transponder centre_frequency="762000000" bandwidth="0" constellation="3"/><!-- Ch 57 -->
+		<transponder centre_frequency="770000000" bandwidth="0" constellation="3"/><!-- Ch 58 -->
 		<transponder centre_frequency="778000000" bandwidth="0" constellation="3"/><!-- Ch 59 -->
+		<transponder centre_frequency="786000000" bandwidth="0" constellation="3"/><!-- Ch 60 -->
+	</terrestrial>
+	<terrestrial name="Castilla-la Mancha (Europe DVB-T/T2)" flags="5" countrycode="ESP">
+		<transponder centre_frequency="474000000" bandwidth="0" constellation="3"/><!-- Ch 21 -->
+		<transponder centre_frequency="482000000" bandwidth="0" constellation="3"/><!-- Ch 22 -->
+		<transponder centre_frequency="490000000" bandwidth="0" constellation="3"/><!-- Ch 23 -->
+		<transponder centre_frequency="498000000" bandwidth="0" constellation="3"/><!-- Ch 24 -->
+		<transponder centre_frequency="506000000" bandwidth="0" constellation="3"/><!-- Ch 25 -->
+		<transponder centre_frequency="514000000" bandwidth="0" constellation="3"/><!-- Ch 26 -->
+		<transponder centre_frequency="522000000" bandwidth="0" constellation="3"/><!-- Ch 27 -->
+		<transponder centre_frequency="530000000" bandwidth="0" constellation="3"/><!-- Ch 28 -->
+		<transponder centre_frequency="538000000" bandwidth="0" constellation="3"/><!-- Ch 29 -->
+		<transponder centre_frequency="546000000" bandwidth="0" constellation="3"/><!-- Ch 30 -->
+		<transponder centre_frequency="554000000" bandwidth="0" constellation="3"/><!-- Ch 31 -->
+		<transponder centre_frequency="562000000" bandwidth="0" constellation="3"/><!-- Ch 32 -->
+		<transponder centre_frequency="570000000" bandwidth="0" constellation="3"/><!-- Ch 33 -->
+		<transponder centre_frequency="578000000" bandwidth="0" constellation="3"/><!-- Ch 34 -->
+		<transponder centre_frequency="586000000" bandwidth="0" constellation="3"/><!-- Ch 35 -->
+		<transponder centre_frequency="594000000" bandwidth="0" constellation="3"/><!-- Ch 36 -->
+		<transponder centre_frequency="602000000" bandwidth="0" constellation="3"/><!-- Ch 37 -->
+		<transponder centre_frequency="610000000" bandwidth="0" constellation="3"/><!-- Ch 38 -->
+		<transponder centre_frequency="618000000" bandwidth="0" constellation="3"/><!-- Ch 39 -->
+		<transponder centre_frequency="626000000" bandwidth="0" constellation="3"/><!-- Ch 40 -->
+		<transponder centre_frequency="634000000" bandwidth="0" constellation="3"/><!-- Ch 41 -->
+		<transponder centre_frequency="642000000" bandwidth="0" constellation="3"/><!-- Ch 42 -->
+		<transponder centre_frequency="650000000" bandwidth="0" constellation="3"/><!-- Ch 43 -->
+		<transponder centre_frequency="658000000" bandwidth="0" constellation="3"/><!-- Ch 44 -->
+		<transponder centre_frequency="666000000" bandwidth="0" constellation="3"/><!-- Ch 45 -->
+		<transponder centre_frequency="674000000" bandwidth="0" constellation="3"/><!-- Ch 46 -->
+		<transponder centre_frequency="682000000" bandwidth="0" constellation="3"/><!-- Ch 47 -->
+		<transponder centre_frequency="690000000" bandwidth="0" constellation="3"/><!-- Ch 48 -->
+		<transponder centre_frequency="698000000" bandwidth="0" constellation="3"/><!-- Ch 49 -->
+		<transponder centre_frequency="706000000" bandwidth="0" constellation="3"/><!-- Ch 50 -->
+		<transponder centre_frequency="714000000" bandwidth="0" constellation="3"/><!-- Ch 51 -->
+		<transponder centre_frequency="722000000" bandwidth="0" constellation="3"/><!-- Ch 52 -->
+		<transponder centre_frequency="730000000" bandwidth="0" constellation="3"/><!-- Ch 53 -->
+		<transponder centre_frequency="738000000" bandwidth="0" constellation="3"/><!-- Ch 54 -->
+		<transponder centre_frequency="746000000" bandwidth="0" constellation="3"/><!-- Ch 55 -->
+		<transponder centre_frequency="754000000" bandwidth="0" constellation="3"/><!-- Ch 56 -->
+		<transponder centre_frequency="762000000" bandwidth="0" constellation="3"/><!-- Ch 57 -->
+		<transponder centre_frequency="770000000" bandwidth="0" constellation="3"/><!-- Ch 58 -->
+		<transponder centre_frequency="778000000" bandwidth="0" constellation="3"/><!-- Ch 59 -->
+		<transponder centre_frequency="786000000" bandwidth="0" constellation="3"/><!-- Ch 60 -->
 	</terrestrial>
 	<terrestrial name="Castilla-Leon (Europe DVB-T/T2)" flags="5" countrycode="ESP">
 		<transponder centre_frequency="474000000" bandwidth="0" constellation="3"/><!-- Ch 21 -->
@@ -1040,16 +1094,20 @@
 		<transponder centre_frequency="506000000" bandwidth="0" constellation="3"/><!-- Ch 25 -->
 		<transponder centre_frequency="514000000" bandwidth="0" constellation="3"/><!-- Ch 26 -->
 		<transponder centre_frequency="522000000" bandwidth="0" constellation="3"/><!-- Ch 27 -->
+		<transponder centre_frequency="530000000" bandwidth="0" constellation="3"/><!-- Ch 28 -->
 		<transponder centre_frequency="538000000" bandwidth="0" constellation="3"/><!-- Ch 29 -->
 		<transponder centre_frequency="546000000" bandwidth="0" constellation="3"/><!-- Ch 30 -->
 		<transponder centre_frequency="554000000" bandwidth="0" constellation="3"/><!-- Ch 31 -->
+		<transponder centre_frequency="562000000" bandwidth="0" constellation="3"/><!-- Ch 32 -->
 		<transponder centre_frequency="570000000" bandwidth="0" constellation="3"/><!-- Ch 33 -->
 		<transponder centre_frequency="578000000" bandwidth="0" constellation="3"/><!-- Ch 34 -->
 		<transponder centre_frequency="586000000" bandwidth="0" constellation="3"/><!-- Ch 35 -->
+		<transponder centre_frequency="594000000" bandwidth="0" constellation="3"/><!-- Ch 36 -->
 		<transponder centre_frequency="602000000" bandwidth="0" constellation="3"/><!-- Ch 37 -->
 		<transponder centre_frequency="610000000" bandwidth="0" constellation="3"/><!-- Ch 38 -->
 		<transponder centre_frequency="618000000" bandwidth="0" constellation="3"/><!-- Ch 39 -->
 		<transponder centre_frequency="626000000" bandwidth="0" constellation="3"/><!-- Ch 40 -->
+		<transponder centre_frequency="634000000" bandwidth="0" constellation="3"/><!-- Ch 41 -->
 		<transponder centre_frequency="642000000" bandwidth="0" constellation="3"/><!-- Ch 42 -->
 		<transponder centre_frequency="650000000" bandwidth="0" constellation="3"/><!-- Ch 43 -->
 		<transponder centre_frequency="658000000" bandwidth="0" constellation="3"/><!-- Ch 44 -->
@@ -1057,108 +1115,167 @@
 		<transponder centre_frequency="674000000" bandwidth="0" constellation="3"/><!-- Ch 46 -->
 		<transponder centre_frequency="682000000" bandwidth="0" constellation="3"/><!-- Ch 47 -->
 		<transponder centre_frequency="690000000" bandwidth="0" constellation="3"/><!-- Ch 48 -->
+		<transponder centre_frequency="698000000" bandwidth="0" constellation="3"/><!-- Ch 49 -->
 		<transponder centre_frequency="706000000" bandwidth="0" constellation="3"/><!-- Ch 50 -->
 		<transponder centre_frequency="714000000" bandwidth="0" constellation="3"/><!-- Ch 51 -->
 		<transponder centre_frequency="722000000" bandwidth="0" constellation="3"/><!-- Ch 52 -->
 		<transponder centre_frequency="730000000" bandwidth="0" constellation="3"/><!-- Ch 53 -->
 		<transponder centre_frequency="738000000" bandwidth="0" constellation="3"/><!-- Ch 54 -->
 		<transponder centre_frequency="746000000" bandwidth="0" constellation="3"/><!-- Ch 55 -->
+		<transponder centre_frequency="754000000" bandwidth="0" constellation="3"/><!-- Ch 56 -->
 		<transponder centre_frequency="762000000" bandwidth="0" constellation="3"/><!-- Ch 57 -->
 		<transponder centre_frequency="770000000" bandwidth="0" constellation="3"/><!-- Ch 58 -->
 		<transponder centre_frequency="778000000" bandwidth="0" constellation="3"/><!-- Ch 59 -->
 		<transponder centre_frequency="786000000" bandwidth="0" constellation="3"/><!-- Ch 60 -->
 	</terrestrial>
 	<terrestrial name="Catalunya (Europe DVB-T/T2)" flags="5" countrycode="ESP">
-		<transponder centre_frequency="490000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="498000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="506000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="514000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="522000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="530000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="538000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="546000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="554000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="562000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="570000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="578000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="586000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="594000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="602000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="610000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="618000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="626000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="634000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="642000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="658000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="666000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="674000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="682000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="690000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="698000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="706000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="714000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="722000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="730000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="738000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="746000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="754000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="762000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="770000000" bandwidth="0" constellation="3"/>
-		<transponder centre_frequency="778000000" bandwidth="0" constellation="3"/>
-	</terrestrial>
-	<terrestrial name="Ceuta y Melilla (Europe DVB-T/T2)" flags="5" countrycode="ESP">
 		<transponder centre_frequency="474000000" bandwidth="0" constellation="3"/><!-- Ch 21 -->
+		<transponder centre_frequency="482000000" bandwidth="0" constellation="3"/><!-- Ch 22 -->
+		<transponder centre_frequency="490000000" bandwidth="0" constellation="3"/><!-- Ch 23 -->
 		<transponder centre_frequency="498000000" bandwidth="0" constellation="3"/><!-- Ch 24 -->
 		<transponder centre_frequency="506000000" bandwidth="0" constellation="3"/><!-- Ch 25 -->
+		<transponder centre_frequency="514000000" bandwidth="0" constellation="3"/><!-- Ch 26 -->
 		<transponder centre_frequency="522000000" bandwidth="0" constellation="3"/><!-- Ch 27 -->
+		<transponder centre_frequency="530000000" bandwidth="0" constellation="3"/><!-- Ch 28 -->
+		<transponder centre_frequency="538000000" bandwidth="0" constellation="3"/><!-- Ch 29 -->
+		<transponder centre_frequency="546000000" bandwidth="0" constellation="3"/><!-- Ch 30 -->
+		<transponder centre_frequency="554000000" bandwidth="0" constellation="3"/><!-- Ch 31 -->
+		<transponder centre_frequency="562000000" bandwidth="0" constellation="3"/><!-- Ch 32 -->
+		<transponder centre_frequency="570000000" bandwidth="0" constellation="3"/><!-- Ch 33 -->
+		<transponder centre_frequency="578000000" bandwidth="0" constellation="3"/><!-- Ch 34 -->
 		<transponder centre_frequency="586000000" bandwidth="0" constellation="3"/><!-- Ch 35 -->
 		<transponder centre_frequency="594000000" bandwidth="0" constellation="3"/><!-- Ch 36 -->
 		<transponder centre_frequency="602000000" bandwidth="0" constellation="3"/><!-- Ch 37 -->
 		<transponder centre_frequency="610000000" bandwidth="0" constellation="3"/><!-- Ch 38 -->
+		<transponder centre_frequency="618000000" bandwidth="0" constellation="3"/><!-- Ch 39 -->
+		<transponder centre_frequency="626000000" bandwidth="0" constellation="3"/><!-- Ch 40 -->
 		<transponder centre_frequency="634000000" bandwidth="0" constellation="3"/><!-- Ch 41 -->
+		<transponder centre_frequency="642000000" bandwidth="0" constellation="3"/><!-- Ch 42 -->
 		<transponder centre_frequency="650000000" bandwidth="0" constellation="3"/><!-- Ch 43 -->
 		<transponder centre_frequency="658000000" bandwidth="0" constellation="3"/><!-- Ch 44 -->
 		<transponder centre_frequency="666000000" bandwidth="0" constellation="3"/><!-- Ch 45 -->
+		<transponder centre_frequency="674000000" bandwidth="0" constellation="3"/><!-- Ch 46 -->
+		<transponder centre_frequency="682000000" bandwidth="0" constellation="3"/><!-- Ch 47 -->
+		<transponder centre_frequency="690000000" bandwidth="0" constellation="3"/><!-- Ch 48 -->
 		<transponder centre_frequency="698000000" bandwidth="0" constellation="3"/><!-- Ch 49 -->
+		<transponder centre_frequency="706000000" bandwidth="0" constellation="3"/><!-- Ch 50 -->
+		<transponder centre_frequency="714000000" bandwidth="0" constellation="3"/><!-- Ch 51 -->
 		<transponder centre_frequency="722000000" bandwidth="0" constellation="3"/><!-- Ch 52 -->
 		<transponder centre_frequency="730000000" bandwidth="0" constellation="3"/><!-- Ch 53 -->
+		<transponder centre_frequency="738000000" bandwidth="0" constellation="3"/><!-- Ch 54 -->
 		<transponder centre_frequency="746000000" bandwidth="0" constellation="3"/><!-- Ch 55 -->
+		<transponder centre_frequency="754000000" bandwidth="0" constellation="3"/><!-- Ch 56 -->
+		<transponder centre_frequency="762000000" bandwidth="0" constellation="3"/><!-- Ch 57 -->
+		<transponder centre_frequency="770000000" bandwidth="0" constellation="3"/><!-- Ch 58 -->
+		<transponder centre_frequency="778000000" bandwidth="0" constellation="3"/><!-- Ch 59 -->
+		<transponder centre_frequency="786000000" bandwidth="0" constellation="3"/><!-- Ch 60 -->
+	</terrestrial>
+	<terrestrial name="Ceuta y Melilla (Europe DVB-T/T2)" flags="5" countrycode="ESP">
+		<transponder centre_frequency="474000000" bandwidth="0" constellation="3"/><!-- Ch 21 -->
+		<transponder centre_frequency="482000000" bandwidth="0" constellation="3"/><!-- Ch 22 -->
+		<transponder centre_frequency="490000000" bandwidth="0" constellation="3"/><!-- Ch 23 -->
+		<transponder centre_frequency="498000000" bandwidth="0" constellation="3"/><!-- Ch 24 -->
+		<transponder centre_frequency="506000000" bandwidth="0" constellation="3"/><!-- Ch 25 -->
+		<transponder centre_frequency="514000000" bandwidth="0" constellation="3"/><!-- Ch 26 -->
+		<transponder centre_frequency="522000000" bandwidth="0" constellation="3"/><!-- Ch 27 -->
+		<transponder centre_frequency="530000000" bandwidth="0" constellation="3"/><!-- Ch 28 -->
+		<transponder centre_frequency="538000000" bandwidth="0" constellation="3"/><!-- Ch 29 -->
+		<transponder centre_frequency="546000000" bandwidth="0" constellation="3"/><!-- Ch 30 -->
+		<transponder centre_frequency="554000000" bandwidth="0" constellation="3"/><!-- Ch 31 -->
+		<transponder centre_frequency="562000000" bandwidth="0" constellation="3"/><!-- Ch 32 -->
+		<transponder centre_frequency="570000000" bandwidth="0" constellation="3"/><!-- Ch 33 -->
+		<transponder centre_frequency="578000000" bandwidth="0" constellation="3"/><!-- Ch 34 -->
+		<transponder centre_frequency="586000000" bandwidth="0" constellation="3"/><!-- Ch 35 -->
+		<transponder centre_frequency="594000000" bandwidth="0" constellation="3"/><!-- Ch 36 -->
+		<transponder centre_frequency="602000000" bandwidth="0" constellation="3"/><!-- Ch 37 -->
+		<transponder centre_frequency="610000000" bandwidth="0" constellation="3"/><!-- Ch 38 -->
+		<transponder centre_frequency="618000000" bandwidth="0" constellation="3"/><!-- Ch 39 -->
+		<transponder centre_frequency="626000000" bandwidth="0" constellation="3"/><!-- Ch 40 -->
+		<transponder centre_frequency="634000000" bandwidth="0" constellation="3"/><!-- Ch 41 -->
+		<transponder centre_frequency="642000000" bandwidth="0" constellation="3"/><!-- Ch 42 -->
+		<transponder centre_frequency="650000000" bandwidth="0" constellation="3"/><!-- Ch 43 -->
+		<transponder centre_frequency="658000000" bandwidth="0" constellation="3"/><!-- Ch 44 -->
+		<transponder centre_frequency="666000000" bandwidth="0" constellation="3"/><!-- Ch 45 -->
+		<transponder centre_frequency="674000000" bandwidth="0" constellation="3"/><!-- Ch 46 -->
+		<transponder centre_frequency="682000000" bandwidth="0" constellation="3"/><!-- Ch 47 -->
+		<transponder centre_frequency="690000000" bandwidth="0" constellation="3"/><!-- Ch 48 -->
+		<transponder centre_frequency="698000000" bandwidth="0" constellation="3"/><!-- Ch 49 -->
+		<transponder centre_frequency="706000000" bandwidth="0" constellation="3"/><!-- Ch 50 -->
+		<transponder centre_frequency="714000000" bandwidth="0" constellation="3"/><!-- Ch 51 -->
+		<transponder centre_frequency="722000000" bandwidth="0" constellation="3"/><!-- Ch 52 -->
+		<transponder centre_frequency="730000000" bandwidth="0" constellation="3"/><!-- Ch 53 -->
+		<transponder centre_frequency="738000000" bandwidth="0" constellation="3"/><!-- Ch 54 -->
+		<transponder centre_frequency="746000000" bandwidth="0" constellation="3"/><!-- Ch 55 -->
+		<transponder centre_frequency="754000000" bandwidth="0" constellation="3"/><!-- Ch 56 -->
+		<transponder centre_frequency="762000000" bandwidth="0" constellation="3"/><!-- Ch 57 -->
+		<transponder centre_frequency="770000000" bandwidth="0" constellation="3"/><!-- Ch 58 -->
+		<transponder centre_frequency="778000000" bandwidth="0" constellation="3"/><!-- Ch 59 -->
+		<transponder centre_frequency="786000000" bandwidth="0" constellation="3"/><!-- Ch 60 -->
 	</terrestrial>
 	<terrestrial name="Comunidad de Madrid (Europe DVB-T/T2)" flags="5" countrycode="ESP">
 		<transponder centre_frequency="474000000" bandwidth="0" constellation="3"/><!-- Ch 21 -->
 		<transponder centre_frequency="482000000" bandwidth="0" constellation="3"/><!-- Ch 22 -->
+		<transponder centre_frequency="490000000" bandwidth="0" constellation="3"/><!-- Ch 23 -->
 		<transponder centre_frequency="498000000" bandwidth="0" constellation="3"/><!-- Ch 24 -->
+		<transponder centre_frequency="506000000" bandwidth="0" constellation="3"/><!-- Ch 25 -->
 		<transponder centre_frequency="514000000" bandwidth="0" constellation="3"/><!-- Ch 26 -->
+		<transponder centre_frequency="522000000" bandwidth="0" constellation="3"/><!-- Ch 27 -->
+		<transponder centre_frequency="530000000" bandwidth="0" constellation="3"/><!-- Ch 28 -->
 		<transponder centre_frequency="538000000" bandwidth="0" constellation="3"/><!-- Ch 29 -->
 		<transponder centre_frequency="546000000" bandwidth="0" constellation="3"/><!-- Ch 30 -->
+		<transponder centre_frequency="554000000" bandwidth="0" constellation="3"/><!-- Ch 31 -->
+		<transponder centre_frequency="562000000" bandwidth="0" constellation="3"/><!-- Ch 32 -->
 		<transponder centre_frequency="570000000" bandwidth="0" constellation="3"/><!-- Ch 33 -->
+		<transponder centre_frequency="578000000" bandwidth="0" constellation="3"/><!-- Ch 34 -->
 		<transponder centre_frequency="586000000" bandwidth="0" constellation="3"/><!-- Ch 35 -->
+		<transponder centre_frequency="594000000" bandwidth="0" constellation="3"/><!-- Ch 36 -->
+		<transponder centre_frequency="602000000" bandwidth="0" constellation="3"/><!-- Ch 37 -->
+		<transponder centre_frequency="610000000" bandwidth="0" constellation="3"/><!-- Ch 38 -->
 		<transponder centre_frequency="618000000" bandwidth="0" constellation="3"/><!-- Ch 39 -->
+		<transponder centre_frequency="626000000" bandwidth="0" constellation="3"/><!-- Ch 40 -->
 		<transponder centre_frequency="634000000" bandwidth="0" constellation="3"/><!-- Ch 41 -->
 		<transponder centre_frequency="642000000" bandwidth="0" constellation="3"/><!-- Ch 42 -->
+		<transponder centre_frequency="650000000" bandwidth="0" constellation="3"/><!-- Ch 43 -->
+		<transponder centre_frequency="658000000" bandwidth="0" constellation="3"/><!-- Ch 44 -->
+		<transponder centre_frequency="666000000" bandwidth="0" constellation="3"/><!-- Ch 45 -->
 		<transponder centre_frequency="674000000" bandwidth="0" constellation="3"/><!-- Ch 46 -->
+		<transponder centre_frequency="682000000" bandwidth="0" constellation="3"/><!-- Ch 47 -->
+		<transponder centre_frequency="690000000" bandwidth="0" constellation="3"/><!-- Ch 48 -->
 		<transponder centre_frequency="698000000" bandwidth="0" constellation="3"/><!-- Ch 49 -->
 		<transponder centre_frequency="706000000" bandwidth="0" constellation="3"/><!-- Ch 50 -->
 		<transponder centre_frequency="714000000" bandwidth="0" constellation="3"/><!-- Ch 51 -->
+		<transponder centre_frequency="722000000" bandwidth="0" constellation="3"/><!-- Ch 52 -->
+		<transponder centre_frequency="730000000" bandwidth="0" constellation="3"/><!-- Ch 53 -->
+		<transponder centre_frequency="738000000" bandwidth="0" constellation="3"/><!-- Ch 54 -->
 		<transponder centre_frequency="746000000" bandwidth="0" constellation="3"/><!-- Ch 55 -->
+		<transponder centre_frequency="754000000" bandwidth="0" constellation="3"/><!-- Ch 56 -->
+		<transponder centre_frequency="762000000" bandwidth="0" constellation="3"/><!-- Ch 57 -->
 		<transponder centre_frequency="770000000" bandwidth="0" constellation="3"/><!-- Ch 58 -->
 		<transponder centre_frequency="778000000" bandwidth="0" constellation="3"/><!-- Ch 59 -->
+		<transponder centre_frequency="786000000" bandwidth="0" constellation="3"/><!-- Ch 60 -->
 	</terrestrial>
 	<terrestrial name="Comunidad Valenciana (Europe DVB-T/T2)" flags="5" countrycode="ESP">
 		<transponder centre_frequency="474000000" bandwidth="0" constellation="3"/><!-- Ch 21 -->
 		<transponder centre_frequency="482000000" bandwidth="0" constellation="3"/><!-- Ch 22 -->
 		<transponder centre_frequency="490000000" bandwidth="0" constellation="3"/><!-- Ch 23 -->
+		<transponder centre_frequency="498000000" bandwidth="0" constellation="3"/><!-- Ch 24 -->
 		<transponder centre_frequency="506000000" bandwidth="0" constellation="3"/><!-- Ch 25 -->
 		<transponder centre_frequency="514000000" bandwidth="0" constellation="3"/><!-- Ch 26 -->
 		<transponder centre_frequency="522000000" bandwidth="0" constellation="3"/><!-- Ch 27 -->
 		<transponder centre_frequency="530000000" bandwidth="0" constellation="3"/><!-- Ch 28 -->
+		<transponder centre_frequency="538000000" bandwidth="0" constellation="3"/><!-- Ch 29 -->
 		<transponder centre_frequency="546000000" bandwidth="0" constellation="3"/><!-- Ch 30 -->
+		<transponder centre_frequency="554000000" bandwidth="0" constellation="3"/><!-- Ch 31 -->
 		<transponder centre_frequency="562000000" bandwidth="0" constellation="3"/><!-- Ch 32 -->
 		<transponder centre_frequency="570000000" bandwidth="0" constellation="3"/><!-- Ch 33 -->
+		<transponder centre_frequency="578000000" bandwidth="0" constellation="3"/><!-- Ch 34 -->
 		<transponder centre_frequency="586000000" bandwidth="0" constellation="3"/><!-- Ch 35 -->
 		<transponder centre_frequency="594000000" bandwidth="0" constellation="3"/><!-- Ch 36 -->
 		<transponder centre_frequency="602000000" bandwidth="0" constellation="3"/><!-- Ch 37 -->
+		<transponder centre_frequency="610000000" bandwidth="0" constellation="3"/><!-- Ch 38 -->
+		<transponder centre_frequency="618000000" bandwidth="0" constellation="3"/><!-- Ch 39 -->
 		<transponder centre_frequency="626000000" bandwidth="0" constellation="3"/><!-- Ch 40 -->
+		<transponder centre_frequency="634000000" bandwidth="0" constellation="3"/><!-- Ch 41 -->
 		<transponder centre_frequency="642000000" bandwidth="0" constellation="3"/><!-- Ch 42 -->
 		<transponder centre_frequency="650000000" bandwidth="0" constellation="3"/><!-- Ch 43 -->
 		<transponder centre_frequency="658000000" bandwidth="0" constellation="3"/><!-- Ch 44 -->
@@ -1168,22 +1285,28 @@
 		<transponder centre_frequency="690000000" bandwidth="0" constellation="3"/><!-- Ch 48 -->
 		<transponder centre_frequency="698000000" bandwidth="0" constellation="3"/><!-- Ch 49 -->
 		<transponder centre_frequency="706000000" bandwidth="0" constellation="3"/><!-- Ch 50 -->
+		<transponder centre_frequency="714000000" bandwidth="0" constellation="3"/><!-- Ch 51 -->
 		<transponder centre_frequency="722000000" bandwidth="0" constellation="3"/><!-- Ch 52 -->
 		<transponder centre_frequency="730000000" bandwidth="0" constellation="3"/><!-- Ch 53 -->
 		<transponder centre_frequency="738000000" bandwidth="0" constellation="3"/><!-- Ch 54 -->
+		<transponder centre_frequency="746000000" bandwidth="0" constellation="3"/><!-- Ch 55 -->
 		<transponder centre_frequency="754000000" bandwidth="0" constellation="3"/><!-- Ch 56 -->
 		<transponder centre_frequency="762000000" bandwidth="0" constellation="3"/><!-- Ch 57 -->
 		<transponder centre_frequency="770000000" bandwidth="0" constellation="3"/><!-- Ch 58 -->
+		<transponder centre_frequency="778000000" bandwidth="0" constellation="3"/><!-- Ch 59 -->
 		<transponder centre_frequency="786000000" bandwidth="0" constellation="3"/><!-- Ch 60 -->
 	</terrestrial>
 	<terrestrial name="Euskadi (Europe DVB-T/T2)" flags="5" countrycode="ESP">
+		<transponder centre_frequency="474000000" bandwidth="0" constellation="3"/><!-- Ch 21 -->
 		<transponder centre_frequency="482000000" bandwidth="0" constellation="3"/><!-- Ch 22 -->
 		<transponder centre_frequency="490000000" bandwidth="0" constellation="3"/><!-- Ch 23 -->
 		<transponder centre_frequency="498000000" bandwidth="0" constellation="3"/><!-- Ch 24 -->
+		<transponder centre_frequency="506000000" bandwidth="0" constellation="3"/><!-- Ch 25 -->
 		<transponder centre_frequency="514000000" bandwidth="0" constellation="3"/><!-- Ch 26 -->
 		<transponder centre_frequency="522000000" bandwidth="0" constellation="3"/><!-- Ch 27 -->
 		<transponder centre_frequency="530000000" bandwidth="0" constellation="3"/><!-- Ch 28 -->
 		<transponder centre_frequency="538000000" bandwidth="0" constellation="3"/><!-- Ch 29 -->
+		<transponder centre_frequency="546000000" bandwidth="0" constellation="3"/><!-- Ch 30 -->
 		<transponder centre_frequency="554000000" bandwidth="0" constellation="3"/><!-- Ch 31 -->
 		<transponder centre_frequency="562000000" bandwidth="0" constellation="3"/><!-- Ch 32 -->
 		<transponder centre_frequency="570000000" bandwidth="0" constellation="3"/><!-- Ch 33 -->
@@ -1192,45 +1315,32 @@
 		<transponder centre_frequency="594000000" bandwidth="0" constellation="3"/><!-- Ch 36 -->
 		<transponder centre_frequency="602000000" bandwidth="0" constellation="3"/><!-- Ch 37 -->
 		<transponder centre_frequency="610000000" bandwidth="0" constellation="3"/><!-- Ch 38 -->
+		<transponder centre_frequency="618000000" bandwidth="0" constellation="3"/><!-- Ch 39 -->
 		<transponder centre_frequency="626000000" bandwidth="0" constellation="3"/><!-- Ch 40 -->
 		<transponder centre_frequency="634000000" bandwidth="0" constellation="3"/><!-- Ch 41 -->
+		<transponder centre_frequency="642000000" bandwidth="0" constellation="3"/><!-- Ch 42 -->
 		<transponder centre_frequency="650000000" bandwidth="0" constellation="3"/><!-- Ch 43 -->
 		<transponder centre_frequency="658000000" bandwidth="0" constellation="3"/><!-- Ch 44 -->
 		<transponder centre_frequency="666000000" bandwidth="0" constellation="3"/><!-- Ch 45 -->
 		<transponder centre_frequency="674000000" bandwidth="0" constellation="3"/><!-- Ch 46 -->
+		<transponder centre_frequency="682000000" bandwidth="0" constellation="3"/><!-- Ch 47 -->
 		<transponder centre_frequency="690000000" bandwidth="0" constellation="3"/><!-- Ch 48 -->
 		<transponder centre_frequency="698000000" bandwidth="0" constellation="3"/><!-- Ch 49 -->
 		<transponder centre_frequency="706000000" bandwidth="0" constellation="3"/><!-- Ch 50 -->
+		<transponder centre_frequency="714000000" bandwidth="0" constellation="3"/><!-- Ch 51 -->
 		<transponder centre_frequency="722000000" bandwidth="0" constellation="3"/><!-- Ch 52 -->
+		<transponder centre_frequency="730000000" bandwidth="0" constellation="3"/><!-- Ch 53 -->
 		<transponder centre_frequency="738000000" bandwidth="0" constellation="3"/><!-- Ch 54 -->
+		<transponder centre_frequency="746000000" bandwidth="0" constellation="3"/><!-- Ch 55 -->
 		<transponder centre_frequency="754000000" bandwidth="0" constellation="3"/><!-- Ch 56 -->
+		<transponder centre_frequency="762000000" bandwidth="0" constellation="3"/><!-- Ch 57 -->
 		<transponder centre_frequency="770000000" bandwidth="0" constellation="3"/><!-- Ch 58 -->
 		<transponder centre_frequency="778000000" bandwidth="0" constellation="3"/><!-- Ch 59 -->
+		<transponder centre_frequency="786000000" bandwidth="0" constellation="3"/><!-- Ch 60 -->
 	</terrestrial>
 	<terrestrial name="Extremadura (Europe DVB-T/T2)" flags="5" countrycode="ESP">
 		<transponder centre_frequency="474000000" bandwidth="0" constellation="3"/><!-- Ch 21 -->
 		<transponder centre_frequency="482000000" bandwidth="0" constellation="3"/><!-- Ch 22 -->
-		<transponder centre_frequency="514000000" bandwidth="0" constellation="3"/><!-- Ch 26 -->
-		<transponder centre_frequency="546000000" bandwidth="0" constellation="3"/><!-- Ch 30 -->
-		<transponder centre_frequency="562000000" bandwidth="0" constellation="3"/><!-- Ch 32 -->
-		<transponder centre_frequency="586000000" bandwidth="0" constellation="3"/><!-- Ch 35 -->
-		<transponder centre_frequency="594000000" bandwidth="0" constellation="3"/><!-- Ch 36 -->
-		<transponder centre_frequency="602000000" bandwidth="0" constellation="3"/><!-- Ch 37 -->
-		<transponder centre_frequency="610000000" bandwidth="0" constellation="3"/><!-- Ch 38 -->
-		<transponder centre_frequency="618000000" bandwidth="0" constellation="3"/><!-- Ch 39 -->
-		<transponder centre_frequency="634000000" bandwidth="0" constellation="3"/><!-- Ch 41 -->
-		<transponder centre_frequency="642000000" bandwidth="0" constellation="3"/><!-- Ch 42 -->
-		<transponder centre_frequency="650000000" bandwidth="0" constellation="3"/><!-- Ch 43 -->
-		<transponder centre_frequency="666000000" bandwidth="0" constellation="3"/><!-- Ch 45 -->
-		<transponder centre_frequency="674000000" bandwidth="0" constellation="3"/><!-- Ch 46 -->
-		<transponder centre_frequency="690000000" bandwidth="0" constellation="3"/><!-- Ch 48 -->
-		<transponder centre_frequency="706000000" bandwidth="0" constellation="3"/><!-- Ch 50 -->
-		<transponder centre_frequency="738000000" bandwidth="0" constellation="3"/><!-- Ch 54 -->
-		<transponder centre_frequency="770000000" bandwidth="0" constellation="3"/><!-- Ch 58 -->
-		<transponder centre_frequency="778000000" bandwidth="0" constellation="3"/><!-- Ch 59 -->
-	</terrestrial>
-	<terrestrial name="Galiza (Europe DVB-T/T2)" flags="5" countrycode="ESP">
-		<transponder centre_frequency="482000000" bandwidth="0" constellation="3"/><!-- Ch 22 -->
 		<transponder centre_frequency="490000000" bandwidth="0" constellation="3"/><!-- Ch 23 -->
 		<transponder centre_frequency="498000000" bandwidth="0" constellation="3"/><!-- Ch 24 -->
 		<transponder centre_frequency="506000000" bandwidth="0" constellation="3"/><!-- Ch 25 -->
@@ -1241,9 +1351,11 @@
 		<transponder centre_frequency="546000000" bandwidth="0" constellation="3"/><!-- Ch 30 -->
 		<transponder centre_frequency="554000000" bandwidth="0" constellation="3"/><!-- Ch 31 -->
 		<transponder centre_frequency="562000000" bandwidth="0" constellation="3"/><!-- Ch 32 -->
+		<transponder centre_frequency="570000000" bandwidth="0" constellation="3"/><!-- Ch 33 -->
 		<transponder centre_frequency="578000000" bandwidth="0" constellation="3"/><!-- Ch 34 -->
 		<transponder centre_frequency="586000000" bandwidth="0" constellation="3"/><!-- Ch 35 -->
 		<transponder centre_frequency="594000000" bandwidth="0" constellation="3"/><!-- Ch 36 -->
+		<transponder centre_frequency="602000000" bandwidth="0" constellation="3"/><!-- Ch 37 -->
 		<transponder centre_frequency="610000000" bandwidth="0" constellation="3"/><!-- Ch 38 -->
 		<transponder centre_frequency="618000000" bandwidth="0" constellation="3"/><!-- Ch 39 -->
 		<transponder centre_frequency="626000000" bandwidth="0" constellation="3"/><!-- Ch 40 -->
@@ -1263,39 +1375,17 @@
 		<transponder centre_frequency="738000000" bandwidth="0" constellation="3"/><!-- Ch 54 -->
 		<transponder centre_frequency="746000000" bandwidth="0" constellation="3"/><!-- Ch 55 -->
 		<transponder centre_frequency="754000000" bandwidth="0" constellation="3"/><!-- Ch 56 -->
+		<transponder centre_frequency="762000000" bandwidth="0" constellation="3"/><!-- Ch 57 -->
 		<transponder centre_frequency="770000000" bandwidth="0" constellation="3"/><!-- Ch 58 -->
 		<transponder centre_frequency="778000000" bandwidth="0" constellation="3"/><!-- Ch 59 -->
+		<transponder centre_frequency="786000000" bandwidth="0" constellation="3"/><!-- Ch 60 -->
 	</terrestrial>
-	<terrestrial name="La Rioja (Europe DVB-T/T2)" flags="5" countrycode="ESP">
-		<transponder centre_frequency="506000000" bandwidth="0" constellation="3"/><!-- Ch 25 -->
-		<transponder centre_frequency="530000000" bandwidth="0" constellation="3"/><!-- Ch 28 -->
-		<transponder centre_frequency="578000000" bandwidth="0" constellation="3"/><!-- Ch 34 -->
-		<transponder centre_frequency="626000000" bandwidth="0" constellation="3"/><!-- Ch 40 -->
-		<transponder centre_frequency="658000000" bandwidth="0" constellation="3"/><!-- Ch 44 -->
-		<transponder centre_frequency="674000000" bandwidth="0" constellation="3"/><!-- Ch 46 -->
-		<transponder centre_frequency="690000000" bandwidth="0" constellation="3"/><!-- Ch 48 -->
-		<transponder centre_frequency="738000000" bandwidth="0" constellation="3"/><!-- Ch 54 -->
-	</terrestrial>
-	<terrestrial name="Murcia (Europe DVB-T/T2)" flags="5" countrycode="ESP">
-		<transponder centre_frequency="514000000" bandwidth="0" constellation="3"/><!-- Ch 26 -->
-		<transponder centre_frequency="530000000" bandwidth="0" constellation="3"/><!-- Ch 28 -->
-		<transponder centre_frequency="538000000" bandwidth="0" constellation="3"/><!-- Ch 29 -->
-		<transponder centre_frequency="554000000" bandwidth="0" constellation="3"/><!-- Ch 31 -->
-		<transponder centre_frequency="594000000" bandwidth="0" constellation="3"/><!-- Ch 36 -->
-		<transponder centre_frequency="610000000" bandwidth="0" constellation="3"/><!-- Ch 38 -->
-		<transponder centre_frequency="618000000" bandwidth="0" constellation="3"/><!-- Ch 39 -->
-		<transponder centre_frequency="642000000" bandwidth="0" constellation="3"/><!-- Ch 42 -->
-		<transponder centre_frequency="658000000" bandwidth="0" constellation="3"/><!-- Ch 44 -->
-		<transponder centre_frequency="682000000" bandwidth="0" constellation="3"/><!-- Ch 47 -->
-		<transponder centre_frequency="706000000" bandwidth="0" constellation="3"/><!-- Ch 50 -->
-		<transponder centre_frequency="714000000" bandwidth="0" constellation="3"/><!-- Ch 51 -->
-		<transponder centre_frequency="746000000" bandwidth="0" constellation="3"/><!-- Ch 55 -->
-		<transponder centre_frequency="754000000" bandwidth="0" constellation="3"/><!-- Ch 56 -->
-		<transponder centre_frequency="778000000" bandwidth="0" constellation="3"/><!-- Ch 59 -->
-	</terrestrial>
-	<terrestrial name="Ses Illes (Europe DVB-T/T2)" flags="5" countrycode="ESP">
+	<terrestrial name="Galiza (Europe DVB-T/T2)" flags="5" countrycode="ESP">
 		<transponder centre_frequency="474000000" bandwidth="0" constellation="3"/><!-- Ch 21 -->
+		<transponder centre_frequency="482000000" bandwidth="0" constellation="3"/><!-- Ch 22 -->
+		<transponder centre_frequency="490000000" bandwidth="0" constellation="3"/><!-- Ch 23 -->
 		<transponder centre_frequency="498000000" bandwidth="0" constellation="3"/><!-- Ch 24 -->
+		<transponder centre_frequency="506000000" bandwidth="0" constellation="3"/><!-- Ch 25 -->
 		<transponder centre_frequency="514000000" bandwidth="0" constellation="3"/><!-- Ch 26 -->
 		<transponder centre_frequency="522000000" bandwidth="0" constellation="3"/><!-- Ch 27 -->
 		<transponder centre_frequency="530000000" bandwidth="0" constellation="3"/><!-- Ch 28 -->
@@ -1303,22 +1393,160 @@
 		<transponder centre_frequency="546000000" bandwidth="0" constellation="3"/><!-- Ch 30 -->
 		<transponder centre_frequency="554000000" bandwidth="0" constellation="3"/><!-- Ch 31 -->
 		<transponder centre_frequency="562000000" bandwidth="0" constellation="3"/><!-- Ch 32 -->
+		<transponder centre_frequency="570000000" bandwidth="0" constellation="3"/><!-- Ch 33 -->
 		<transponder centre_frequency="578000000" bandwidth="0" constellation="3"/><!-- Ch 34 -->
 		<transponder centre_frequency="586000000" bandwidth="0" constellation="3"/><!-- Ch 35 -->
 		<transponder centre_frequency="594000000" bandwidth="0" constellation="3"/><!-- Ch 36 -->
 		<transponder centre_frequency="602000000" bandwidth="0" constellation="3"/><!-- Ch 37 -->
 		<transponder centre_frequency="610000000" bandwidth="0" constellation="3"/><!-- Ch 38 -->
+		<transponder centre_frequency="618000000" bandwidth="0" constellation="3"/><!-- Ch 39 -->
 		<transponder centre_frequency="626000000" bandwidth="0" constellation="3"/><!-- Ch 40 -->
 		<transponder centre_frequency="634000000" bandwidth="0" constellation="3"/><!-- Ch 41 -->
 		<transponder centre_frequency="642000000" bandwidth="0" constellation="3"/><!-- Ch 42 -->
+		<transponder centre_frequency="650000000" bandwidth="0" constellation="3"/><!-- Ch 43 -->
+		<transponder centre_frequency="658000000" bandwidth="0" constellation="3"/><!-- Ch 44 -->
 		<transponder centre_frequency="666000000" bandwidth="0" constellation="3"/><!-- Ch 45 -->
 		<transponder centre_frequency="674000000" bandwidth="0" constellation="3"/><!-- Ch 46 -->
 		<transponder centre_frequency="682000000" bandwidth="0" constellation="3"/><!-- Ch 47 -->
 		<transponder centre_frequency="690000000" bandwidth="0" constellation="3"/><!-- Ch 48 -->
+		<transponder centre_frequency="698000000" bandwidth="0" constellation="3"/><!-- Ch 49 -->
+		<transponder centre_frequency="706000000" bandwidth="0" constellation="3"/><!-- Ch 50 -->
 		<transponder centre_frequency="714000000" bandwidth="0" constellation="3"/><!-- Ch 51 -->
+		<transponder centre_frequency="722000000" bandwidth="0" constellation="3"/><!-- Ch 52 -->
 		<transponder centre_frequency="730000000" bandwidth="0" constellation="3"/><!-- Ch 53 -->
 		<transponder centre_frequency="738000000" bandwidth="0" constellation="3"/><!-- Ch 54 -->
 		<transponder centre_frequency="746000000" bandwidth="0" constellation="3"/><!-- Ch 55 -->
+		<transponder centre_frequency="754000000" bandwidth="0" constellation="3"/><!-- Ch 56 -->
+		<transponder centre_frequency="762000000" bandwidth="0" constellation="3"/><!-- Ch 57 -->
+		<transponder centre_frequency="770000000" bandwidth="0" constellation="3"/><!-- Ch 58 -->
+		<transponder centre_frequency="778000000" bandwidth="0" constellation="3"/><!-- Ch 59 -->
+		<transponder centre_frequency="786000000" bandwidth="0" constellation="3"/><!-- Ch 60 -->
+	</terrestrial>
+	<terrestrial name="La Rioja (Europe DVB-T/T2)" flags="5" countrycode="ESP">
+		<transponder centre_frequency="474000000" bandwidth="0" constellation="3"/><!-- Ch 21 -->
+		<transponder centre_frequency="482000000" bandwidth="0" constellation="3"/><!-- Ch 22 -->
+		<transponder centre_frequency="490000000" bandwidth="0" constellation="3"/><!-- Ch 23 -->
+		<transponder centre_frequency="498000000" bandwidth="0" constellation="3"/><!-- Ch 24 -->
+		<transponder centre_frequency="506000000" bandwidth="0" constellation="3"/><!-- Ch 25 -->
+		<transponder centre_frequency="514000000" bandwidth="0" constellation="3"/><!-- Ch 26 -->
+		<transponder centre_frequency="522000000" bandwidth="0" constellation="3"/><!-- Ch 27 -->
+		<transponder centre_frequency="530000000" bandwidth="0" constellation="3"/><!-- Ch 28 -->
+		<transponder centre_frequency="538000000" bandwidth="0" constellation="3"/><!-- Ch 29 -->
+		<transponder centre_frequency="546000000" bandwidth="0" constellation="3"/><!-- Ch 30 -->
+		<transponder centre_frequency="554000000" bandwidth="0" constellation="3"/><!-- Ch 31 -->
+		<transponder centre_frequency="562000000" bandwidth="0" constellation="3"/><!-- Ch 32 -->
+		<transponder centre_frequency="570000000" bandwidth="0" constellation="3"/><!-- Ch 33 -->
+		<transponder centre_frequency="578000000" bandwidth="0" constellation="3"/><!-- Ch 34 -->
+		<transponder centre_frequency="586000000" bandwidth="0" constellation="3"/><!-- Ch 35 -->
+		<transponder centre_frequency="594000000" bandwidth="0" constellation="3"/><!-- Ch 36 -->
+		<transponder centre_frequency="602000000" bandwidth="0" constellation="3"/><!-- Ch 37 -->
+		<transponder centre_frequency="610000000" bandwidth="0" constellation="3"/><!-- Ch 38 -->
+		<transponder centre_frequency="618000000" bandwidth="0" constellation="3"/><!-- Ch 39 -->
+		<transponder centre_frequency="626000000" bandwidth="0" constellation="3"/><!-- Ch 40 -->
+		<transponder centre_frequency="634000000" bandwidth="0" constellation="3"/><!-- Ch 41 -->
+		<transponder centre_frequency="642000000" bandwidth="0" constellation="3"/><!-- Ch 42 -->
+		<transponder centre_frequency="650000000" bandwidth="0" constellation="3"/><!-- Ch 43 -->
+		<transponder centre_frequency="658000000" bandwidth="0" constellation="3"/><!-- Ch 44 -->
+		<transponder centre_frequency="666000000" bandwidth="0" constellation="3"/><!-- Ch 45 -->
+		<transponder centre_frequency="674000000" bandwidth="0" constellation="3"/><!-- Ch 46 -->
+		<transponder centre_frequency="682000000" bandwidth="0" constellation="3"/><!-- Ch 47 -->
+		<transponder centre_frequency="690000000" bandwidth="0" constellation="3"/><!-- Ch 48 -->
+		<transponder centre_frequency="698000000" bandwidth="0" constellation="3"/><!-- Ch 49 -->
+		<transponder centre_frequency="706000000" bandwidth="0" constellation="3"/><!-- Ch 50 -->
+		<transponder centre_frequency="714000000" bandwidth="0" constellation="3"/><!-- Ch 51 -->
+		<transponder centre_frequency="722000000" bandwidth="0" constellation="3"/><!-- Ch 52 -->
+		<transponder centre_frequency="730000000" bandwidth="0" constellation="3"/><!-- Ch 53 -->
+		<transponder centre_frequency="738000000" bandwidth="0" constellation="3"/><!-- Ch 54 -->
+		<transponder centre_frequency="746000000" bandwidth="0" constellation="3"/><!-- Ch 55 -->
+		<transponder centre_frequency="754000000" bandwidth="0" constellation="3"/><!-- Ch 56 -->
+		<transponder centre_frequency="762000000" bandwidth="0" constellation="3"/><!-- Ch 57 -->
+		<transponder centre_frequency="770000000" bandwidth="0" constellation="3"/><!-- Ch 58 -->
+		<transponder centre_frequency="778000000" bandwidth="0" constellation="3"/><!-- Ch 59 -->
+		<transponder centre_frequency="786000000" bandwidth="0" constellation="3"/><!-- Ch 60 -->
+	</terrestrial>
+	<terrestrial name="Murcia (Europe DVB-T/T2)" flags="5" countrycode="ESP">
+		<transponder centre_frequency="474000000" bandwidth="0" constellation="3"/><!-- Ch 21 -->
+		<transponder centre_frequency="482000000" bandwidth="0" constellation="3"/><!-- Ch 22 -->
+		<transponder centre_frequency="490000000" bandwidth="0" constellation="3"/><!-- Ch 23 -->
+		<transponder centre_frequency="498000000" bandwidth="0" constellation="3"/><!-- Ch 24 -->
+		<transponder centre_frequency="506000000" bandwidth="0" constellation="3"/><!-- Ch 25 -->
+		<transponder centre_frequency="514000000" bandwidth="0" constellation="3"/><!-- Ch 26 -->
+		<transponder centre_frequency="522000000" bandwidth="0" constellation="3"/><!-- Ch 27 -->
+		<transponder centre_frequency="530000000" bandwidth="0" constellation="3"/><!-- Ch 28 -->
+		<transponder centre_frequency="538000000" bandwidth="0" constellation="3"/><!-- Ch 29 -->
+		<transponder centre_frequency="546000000" bandwidth="0" constellation="3"/><!-- Ch 30 -->
+		<transponder centre_frequency="554000000" bandwidth="0" constellation="3"/><!-- Ch 31 -->
+		<transponder centre_frequency="562000000" bandwidth="0" constellation="3"/><!-- Ch 32 -->
+		<transponder centre_frequency="570000000" bandwidth="0" constellation="3"/><!-- Ch 33 -->
+		<transponder centre_frequency="578000000" bandwidth="0" constellation="3"/><!-- Ch 34 -->
+		<transponder centre_frequency="586000000" bandwidth="0" constellation="3"/><!-- Ch 35 -->
+		<transponder centre_frequency="594000000" bandwidth="0" constellation="3"/><!-- Ch 36 -->
+		<transponder centre_frequency="602000000" bandwidth="0" constellation="3"/><!-- Ch 37 -->
+		<transponder centre_frequency="610000000" bandwidth="0" constellation="3"/><!-- Ch 38 -->
+		<transponder centre_frequency="618000000" bandwidth="0" constellation="3"/><!-- Ch 39 -->
+		<transponder centre_frequency="626000000" bandwidth="0" constellation="3"/><!-- Ch 40 -->
+		<transponder centre_frequency="634000000" bandwidth="0" constellation="3"/><!-- Ch 41 -->
+		<transponder centre_frequency="642000000" bandwidth="0" constellation="3"/><!-- Ch 42 -->
+		<transponder centre_frequency="650000000" bandwidth="0" constellation="3"/><!-- Ch 43 -->
+		<transponder centre_frequency="658000000" bandwidth="0" constellation="3"/><!-- Ch 44 -->
+		<transponder centre_frequency="666000000" bandwidth="0" constellation="3"/><!-- Ch 45 -->
+		<transponder centre_frequency="674000000" bandwidth="0" constellation="3"/><!-- Ch 46 -->
+		<transponder centre_frequency="682000000" bandwidth="0" constellation="3"/><!-- Ch 47 -->
+		<transponder centre_frequency="690000000" bandwidth="0" constellation="3"/><!-- Ch 48 -->
+		<transponder centre_frequency="698000000" bandwidth="0" constellation="3"/><!-- Ch 49 -->
+		<transponder centre_frequency="706000000" bandwidth="0" constellation="3"/><!-- Ch 50 -->
+		<transponder centre_frequency="714000000" bandwidth="0" constellation="3"/><!-- Ch 51 -->
+		<transponder centre_frequency="722000000" bandwidth="0" constellation="3"/><!-- Ch 52 -->
+		<transponder centre_frequency="730000000" bandwidth="0" constellation="3"/><!-- Ch 53 -->
+		<transponder centre_frequency="738000000" bandwidth="0" constellation="3"/><!-- Ch 54 -->
+		<transponder centre_frequency="746000000" bandwidth="0" constellation="3"/><!-- Ch 55 -->
+		<transponder centre_frequency="754000000" bandwidth="0" constellation="3"/><!-- Ch 56 -->
+		<transponder centre_frequency="762000000" bandwidth="0" constellation="3"/><!-- Ch 57 -->
+		<transponder centre_frequency="770000000" bandwidth="0" constellation="3"/><!-- Ch 58 -->
+		<transponder centre_frequency="778000000" bandwidth="0" constellation="3"/><!-- Ch 59 -->
+		<transponder centre_frequency="786000000" bandwidth="0" constellation="3"/><!-- Ch 60 -->
+	</terrestrial>
+	<terrestrial name="Ses Illes (Europe DVB-T/T2)" flags="5" countrycode="ESP">
+		<transponder centre_frequency="474000000" bandwidth="0" constellation="3"/><!-- Ch 21 -->
+		<transponder centre_frequency="482000000" bandwidth="0" constellation="3"/><!-- Ch 22 -->
+		<transponder centre_frequency="490000000" bandwidth="0" constellation="3"/><!-- Ch 23 -->
+		<transponder centre_frequency="498000000" bandwidth="0" constellation="3"/><!-- Ch 24 -->
+		<transponder centre_frequency="506000000" bandwidth="0" constellation="3"/><!-- Ch 25 -->
+		<transponder centre_frequency="514000000" bandwidth="0" constellation="3"/><!-- Ch 26 -->
+		<transponder centre_frequency="522000000" bandwidth="0" constellation="3"/><!-- Ch 27 -->
+		<transponder centre_frequency="530000000" bandwidth="0" constellation="3"/><!-- Ch 28 -->
+		<transponder centre_frequency="538000000" bandwidth="0" constellation="3"/><!-- Ch 29 -->
+		<transponder centre_frequency="546000000" bandwidth="0" constellation="3"/><!-- Ch 30 -->
+		<transponder centre_frequency="554000000" bandwidth="0" constellation="3"/><!-- Ch 31 -->
+		<transponder centre_frequency="562000000" bandwidth="0" constellation="3"/><!-- Ch 32 -->
+		<transponder centre_frequency="570000000" bandwidth="0" constellation="3"/><!-- Ch 33 -->
+		<transponder centre_frequency="578000000" bandwidth="0" constellation="3"/><!-- Ch 34 -->
+		<transponder centre_frequency="586000000" bandwidth="0" constellation="3"/><!-- Ch 35 -->
+		<transponder centre_frequency="594000000" bandwidth="0" constellation="3"/><!-- Ch 36 -->
+		<transponder centre_frequency="602000000" bandwidth="0" constellation="3"/><!-- Ch 37 -->
+		<transponder centre_frequency="610000000" bandwidth="0" constellation="3"/><!-- Ch 38 -->
+		<transponder centre_frequency="618000000" bandwidth="0" constellation="3"/><!-- Ch 39 -->
+		<transponder centre_frequency="626000000" bandwidth="0" constellation="3"/><!-- Ch 40 -->
+		<transponder centre_frequency="634000000" bandwidth="0" constellation="3"/><!-- Ch 41 -->
+		<transponder centre_frequency="642000000" bandwidth="0" constellation="3"/><!-- Ch 42 -->
+		<transponder centre_frequency="650000000" bandwidth="0" constellation="3"/><!-- Ch 43 -->
+		<transponder centre_frequency="658000000" bandwidth="0" constellation="3"/><!-- Ch 44 -->
+		<transponder centre_frequency="666000000" bandwidth="0" constellation="3"/><!-- Ch 45 -->
+		<transponder centre_frequency="674000000" bandwidth="0" constellation="3"/><!-- Ch 46 -->
+		<transponder centre_frequency="682000000" bandwidth="0" constellation="3"/><!-- Ch 47 -->
+		<transponder centre_frequency="690000000" bandwidth="0" constellation="3"/><!-- Ch 48 -->
+		<transponder centre_frequency="698000000" bandwidth="0" constellation="3"/><!-- Ch 49 -->
+		<transponder centre_frequency="706000000" bandwidth="0" constellation="3"/><!-- Ch 50 -->
+		<transponder centre_frequency="714000000" bandwidth="0" constellation="3"/><!-- Ch 51 -->
+		<transponder centre_frequency="722000000" bandwidth="0" constellation="3"/><!-- Ch 52 -->
+		<transponder centre_frequency="730000000" bandwidth="0" constellation="3"/><!-- Ch 53 -->
+		<transponder centre_frequency="738000000" bandwidth="0" constellation="3"/><!-- Ch 54 -->
+		<transponder centre_frequency="746000000" bandwidth="0" constellation="3"/><!-- Ch 55 -->
+		<transponder centre_frequency="754000000" bandwidth="0" constellation="3"/><!-- Ch 56 -->
+		<transponder centre_frequency="762000000" bandwidth="0" constellation="3"/><!-- Ch 57 -->
+		<transponder centre_frequency="770000000" bandwidth="0" constellation="3"/><!-- Ch 58 -->
+		<transponder centre_frequency="778000000" bandwidth="0" constellation="3"/><!-- Ch 59 -->
+		<transponder centre_frequency="786000000" bandwidth="0" constellation="3"/><!-- Ch 60 -->
 	</terrestrial>
 	<terrestrial name="Latvia - Kuldīga, Ventspils, Dundaga bezmaksas (Europe DVB-T)" flags="0" countrycode="LVA">
 		<transponder centre_frequency="546000000" bandwidth="0" constellation="3" system="0"/>


### PR DESCRIPTION
I live in the "Euskadi" region of Spain and I recently lost some channels I couldn't tune again. The TV channels where moved to channel 21 of DVB-T and this UHF channel was not listed for the "Euskadi" region of Spain.

Since January 2015 channels from 21 to 60 (both included) of UHF can be used in Spain to broadcast TV channels. Not every region uses all of the UHF channels at this time, but they could begin to broadcast new TV channels or to move existing channels. So I understand, it is better to include the full range of channels from 21 to 60 in every region of Spain.

I would like to point out that since April 2020 TV channels are scheduled to be limited to UHF channels from 21 to 48 (both included).

A good reference for DVB-T in Spain: https://www.mundoplus.tv/zonatdt/tdt_espana.php