### PR TITLE
Add portugal DVB-T frequencies

### DIFF
--- a/src/terrestrial.xml
+++ b/src/terrestrial.xml
@@ -3388,6 +3388,24 @@
 		<transponder centre_frequency="610000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 38 DVB-T2 HEVC test emission -->
 		<transponder centre_frequency="666000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 45 -->
 	</terrestrial>
+	<terrestrial name="Portugal (Europe DVB-T)" flags="5" countrycode="PRT">
+		<!-- https://tdt.telecom.pt/emissores -->
+		<transponder centre_frequency="546000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 30 -->
+		<transponder centre_frequency="570000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 33 -->
+		<transponder centre_frequency="578000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 34 -->
+		<transponder centre_frequency="586000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 35 -->
+		<transponder centre_frequency="594000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 36 -->
+		<transponder centre_frequency="602000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 37 -->
+		<transponder centre_frequency="626000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 40 -->
+		<transponder centre_frequency="634000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 41 -->
+		<transponder centre_frequency="642000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 42 -->
+		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 43 -->
+		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 44 -->
+		<transponder centre_frequency="666000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 45 -->
+		<transponder centre_frequency="674000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 46 -->
+		<transponder centre_frequency="682000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 47 -->
+		<transponder centre_frequency="690000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 48 -->
+	</terrestrial>
 	<terrestrial name="Russia (Europe DVB-T/T2)" flags="5" countrycode="RUS">
 		<transponder centre_frequency="498000000" bandwidth="0" constellation="3" />
 		<transponder centre_frequency="514000000" bandwidth="0" constellation="3" />


### PR DESCRIPTION
Add the Portuguese DVB-T frequencies,
all official info at https://tdt.telecom.pt/emissores