### PR TITLE
[Terrestrial] Update Portuguese TDT: 31-05-2022

### DIFF
--- a/src/terrestrial.xml
+++ b/src/terrestrial.xml
@@ -3041,22 +3041,23 @@
 		<transponder centre_frequency="666000000" bandwidth="0" constellation="3" system="1" /> <!-- Ch 45 -->
 	</terrestrial>
 	<terrestrial name="Portugal (Europe DVB-T)" flags="5" countrycode="PRT">
-		<!-- https://tdt.telecom.pt/emissores -->
-		<transponder centre_frequency="546000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 30 -->
-		<transponder centre_frequency="570000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 33 -->
-		<transponder centre_frequency="578000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 34 -->
-		<transponder centre_frequency="586000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 35 -->
-		<transponder centre_frequency="594000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 36 -->
-		<transponder centre_frequency="602000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 37 -->
-		<transponder centre_frequency="626000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 40 -->
-		<transponder centre_frequency="634000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 41 -->
-		<transponder centre_frequency="642000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 42 -->
-		<transponder centre_frequency="650000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 43 -->
-		<transponder centre_frequency="658000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 44 -->
-		<transponder centre_frequency="666000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 45 -->
-		<transponder centre_frequency="674000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 46 -->
-		<transponder centre_frequency="682000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 47 -->
-		<transponder centre_frequency="690000000" bandwidth="0" constellation="3" system="0" /> <!-- Ch 48 -->
+		<!-- https://tdt.telecom.pt/emissores (last list update: 31-05-2022) -->
+		<transponder centre_frequency="530000000" system="0" bandwidth="0" constellation="2" code_rate_hp="1" code_rate_lp="0" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="0" />
+		<transponder centre_frequency="546000000" system="0" bandwidth="0" constellation="2" code_rate_hp="1" code_rate_lp="0" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="0" />
+		<transponder centre_frequency="570000000" system="0" bandwidth="0" constellation="2" code_rate_hp="1" code_rate_lp="0" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="0" />
+		<transponder centre_frequency="578000000" system="0" bandwidth="0" constellation="2" code_rate_hp="1" code_rate_lp="0" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="0" />
+		<transponder centre_frequency="586000000" system="0" bandwidth="0" constellation="2" code_rate_hp="1" code_rate_lp="0" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="0" />
+		<transponder centre_frequency="594000000" system="0" bandwidth="0" constellation="2" code_rate_hp="1" code_rate_lp="0" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="0" />
+		<transponder centre_frequency="602000000" system="0" bandwidth="0" constellation="2" code_rate_hp="1" code_rate_lp="0" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="0" />
+		<transponder centre_frequency="626000000" system="0" bandwidth="0" constellation="2" code_rate_hp="1" code_rate_lp="0" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="0" />
+		<transponder centre_frequency="634000000" system="0" bandwidth="0" constellation="2" code_rate_hp="1" code_rate_lp="0" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="0" />
+		<transponder centre_frequency="642000000" system="0" bandwidth="0" constellation="2" code_rate_hp="1" code_rate_lp="0" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="0" />
+		<transponder centre_frequency="650000000" system="0" bandwidth="0" constellation="2" code_rate_hp="1" code_rate_lp="0" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="0" />
+		<transponder centre_frequency="658000000" system="0" bandwidth="0" constellation="2" code_rate_hp="1" code_rate_lp="0" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="0" />
+		<transponder centre_frequency="666000000" system="0" bandwidth="0" constellation="2" code_rate_hp="1" code_rate_lp="0" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="0" />
+		<transponder centre_frequency="674000000" system="0" bandwidth="0" constellation="2" code_rate_hp="1" code_rate_lp="0" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="0" />
+		<transponder centre_frequency="682000000" system="0" bandwidth="0" constellation="2" code_rate_hp="1" code_rate_lp="0" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="0" />
+		<transponder centre_frequency="690000000" system="0" bandwidth="0" constellation="2" code_rate_hp="1" code_rate_lp="0" guard_interval="3" transmission_mode="1" hierarchy_information="0" inversion="0" />
 	</terrestrial>
 	<terrestrial name="Russia (Europe DVB-T/T2)" flags="5" countrycode="RUS">
 		<transponder centre_frequency="498000000" bandwidth="0" constellation="3" />


### PR DESCRIPTION
Update from the official TDT site: latest site update 31-05-2022

I share my "one-liner" command to retrieve from official TDT site new updates:
```
wget -q -O- 'https://servicos.apps.meo.pt/Services/TDTService.svc/emissores' | python3 -c "import sys, json, unicodedata, re; a=json.load(sys.stdin); b={}
for c in a: d=c['Frequencia'].replace(' ','')[:7].split('-'); b[c['EstacaoEmissora']]=str((int(d[0])+int(d[1]))*1000000//2)
print('\nUpdate for the file \"terrestrial_pt_tdt.xml\":'); t='\t\t<configuration key=\"{}\" frequency=\"{}\">{}</configuration>'
for c,d in sorted(b.items()): print(t.format(re.sub(r'[^a-z0-9]+','_',unicodedata.normalize('NFD',c.lower()).encode('ascii','ignore').decode('utf-8')),d,c))
print('\nUpdate for the file \"terrestrial.xml\":'); t='\t\t<transponder centre_frequency=\"{}\" system=\"0\" bandwidth=\"0\" constellation=\"2\" code_rate_hp=\"1\" code_rate_lp=\"0\" guard_interval=\"3\" transmission_mode=\"1\" hierarchy_information=\"0\" inversion=\"0\" />'
for c in sorted(set(b.values())): print(t.format(c))"
```